### PR TITLE
Installation script that also extends schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,11 @@ Building
 
 Installation
 ------------
-Copy the resulting JAR file to Joern's `lib` directory. Next time you
-start joern, type `run`. Your extension should be listed.
+Check whether the `JOERN_INSTALL` variable is set to your Joern installation directory, then run:
 
-
-```bash
-   cp target/universal/stage/lib/io.shiftleft.joern-sample-extension-*.jar $joern_install/lib/
-   cp target/universal/stage/lib/org.eclipse.jgit.org.eclipse.jgit* $joern_install/lib/
 ```
-
-where `$joern_install` is the directory where you installed Joern/Ocular.
+./install.sh
+```
 
 Running
 -------

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,23 @@
-readonly JOERN_INSTALL=~/bin/joern/
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+set -o nounset
 
+readonly JOERN_INSTALL=~/bin/joern/
+readonly JAR_INSTALL_DIR=${JOERN_INSTALL}/joern-cli/lib/
+readonly SCHEMA_DIR=src/main/schema/
+
+echo "Examining Joern installation..."
+
+if [ ! -d "${JOERN_INSTALL}" ]; then
+    echo "Cannot find Joern installation at ${JOERN_INSTALL}"
+    echo "Please install Joern first"
+    exit
+fi
+
+echo "Compiling (sbt stage)..."
 sbt stage
-cp target/universal/stage/lib/io.joern.joern-sample-extension-*.jar ${JOERN_INSTALL}/joern-cli/lib/
-cp target/universal/stage/lib/org.eclipse.jgit.org.eclipse.jgit* ${JOERN_INSTALL}/joern-cli/lib/
+
+echo "Installing jars into: ${JAR_INSTALL_DIR}"
+cp target/universal/stage/lib/io.joern.joern-sample-extension-*.jar ${JAR_INSTALL_DIR}
+cp target/universal/stage/lib/org.eclipse.jgit.org.eclipse.jgit* ${JAR_INSTALL_DIR}

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,10 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-readonly JOERN_INSTALL=~/bin/joern/
-readonly JAR_INSTALL_DIR=${JOERN_INSTALL}/joern-cli/lib/
-readonly SCHEMA_DIR=src/main/schema/
+readonly JOERN_INSTALL=~/bin/joern/joern-cli
+readonly JAR_INSTALL_DIR=${JOERN_INSTALL}/lib/
+
+readonly SCHEMA_SRC_DIR=src/main/schema/
 
 echo "Examining Joern installation..."
 
@@ -21,3 +22,8 @@ sbt stage
 echo "Installing jars into: ${JAR_INSTALL_DIR}"
 cp target/universal/stage/lib/io.joern.joern-sample-extension-*.jar ${JAR_INSTALL_DIR}
 cp target/universal/stage/lib/org.eclipse.jgit.org.eclipse.jgit* ${JAR_INSTALL_DIR}
+
+echo "Adapting CPG schema"
+pushd $JOERN_INSTALL
+./schema-extender.sh
+popd

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,5 @@
+readonly JOERN_INSTALL=~/bin/joern/
+
+sbt stage
+cp target/universal/stage/lib/io.joern.joern-sample-extension-*.jar ${JOERN_INSTALL}/joern-cli/lib/
+cp target/universal/stage/lib/org.eclipse.jgit.org.eclipse.jgit* ${JOERN_INSTALL}/joern-cli/lib/

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ set -o nounset
 readonly JOERN_INSTALL=~/bin/joern/joern-cli
 readonly JAR_INSTALL_DIR=${JOERN_INSTALL}/lib/
 
-readonly SCHEMA_SRC_DIR=src/main/schema/
+readonly SCHEMA_SRC_DIR=src/main/resources/schema/
 
 echo "Examining Joern installation..."
 
@@ -24,6 +24,7 @@ cp target/universal/stage/lib/io.joern.joern-sample-extension-*.jar ${JAR_INSTAL
 cp target/universal/stage/lib/org.eclipse.jgit.org.eclipse.jgit* ${JAR_INSTALL_DIR}
 
 echo "Adapting CPG schema"
+cp ${SCHEMA_SRC_DIR}/*.json ${JOERN_INSTALL}/schema-extender/schemas/
 pushd $JOERN_INSTALL
 ./schema-extender.sh
 popd

--- a/src/main/resources/schema/ext.json
+++ b/src/main/resources/schema/ext.json
@@ -4,6 +4,6 @@
   ],
 
   "nodeTypes" : [
-    { "name" : "FILE", "outEdges" : [{"edgeName": "FOO", "inNodes": ["METHOD"]}] }
+      { "name" : "FILE", "outEdges" : [{"edgeName": "FOO", "inNodes": [{"name": "METHOD"}]}] }
   ]
 }

--- a/src/main/schema/ext.json
+++ b/src/main/schema/ext.json
@@ -1,0 +1,9 @@
+{
+  "edgeTypes" : [
+    {"id" : 9000, "name": "FOO", "comment" : "Foo edge", "keys": []}
+  ],
+
+  "nodeTypes" : [
+    { "name" : "FILE", "outEdges" : [{"edgeName": "FOO", "inNodes": ["METHOD"]}] }
+  ]
+}


### PR DESCRIPTION
Supplied a very simple script to install the extension into an existing joern installation. The script also copies over schema schema extension files from `src/main/resources/schema` and runs the schema-extender.

A problem remains: while the CPG with extended schema is now available in the joern installation, one does not have access to it during development. I am wondering whether schema-extender can install the CPG with extended schema into the local maven repository and whether we can then pick up that locally installed extended version of the CPG build in the extension build.sbt.